### PR TITLE
Don't try to pull previous images to use as cache

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: unlock git-crypt secrets
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
@@ -29,31 +29,31 @@ jobs:
           # that github *is* passing the variable into the container too.
           # Given that this is our git crypt key, I'm scared
           args: -c "echo ${GIT_CRYPT_KEY} | base64 -d | git crypt unlock - && git crypt status"
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: build & push image if needed
         with:
-          args: build tess-public --check-registry --push
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+          args: build tess-public --check-registry --push --no-cache
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: Setup Helm
         with:
           entrypoint: /bin/bash
           args: -c "helm init --client-only && helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/ && helm repo update"
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: Deploy tess-public to staging
         if: github.ref == 'refs/heads/staging'
         with:
           args: deploy tess-public hub staging
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: Deploy tess-private to staging
         if: github.ref == 'refs/heads/staging'
         with:
           args: deploy tess-private hub staging
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: Deploy tess-public to prod
         if: github.ref == 'refs/heads/prod'
         with:
           args: deploy tess-public hub prod
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: Deploy tess-private to prod
         if: github.ref == 'refs/heads/prod'
         with:

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://yuvipanda/hubploy:20200219094916edf788
+      - uses: docker://yuvipanda/hubploy:2020030311412566ccc2
         name: test building image
         with:
-          args: build tess-public
+          args: build tess-public --no-cache


### PR DESCRIPTION
Unfortunately, we are bumping into the 14G disk space limit
on GitHub actions, and can not do this - our image is already
about 9G uncompressed.